### PR TITLE
Feature/multiple empty lines in description

### DIFF
--- a/lib/breakdown-stringify.js
+++ b/lib/breakdown-stringify.js
@@ -54,11 +54,9 @@ export default BreakdownStringify = (function () {
             let description = BreakdownUtil.getDescription(issue);
             for (let line of description) {
                 line = BreakdownUtil.trim(line);
-                if (line) {
-                    result += '\t\t\t//';
-                    result += line;
-                    result += BreakdownEnvironment.getEditorLineEnding();
-                }
+                result += '\t\t\t//';
+                result += line;
+                result += BreakdownEnvironment.getEditorLineEnding();
             }
 
             return result;

--- a/lib/breakdown-util.js
+++ b/lib/breakdown-util.js
@@ -427,7 +427,7 @@ export default BreakdownUtil = (function () {
         getDescription(issue) {
             if (issue.fields.description) {
                 let description = issue.fields.description;
-                return String(description).split('\r\n')
+                return String(description).split('\n')
             }
             return [];
         },

--- a/lib/breakdown-util.js
+++ b/lib/breakdown-util.js
@@ -427,7 +427,7 @@ export default BreakdownUtil = (function () {
         getDescription(issue) {
             if (issue.fields.description) {
                 let description = issue.fields.description;
-                return String(description).split('\r\n').filter(line => line); //remove empty lines
+                return String(description).split('\r\n')
             }
             return [];
         },


### PR DESCRIPTION
Hi.

First of all, thanks for the great software!

I've noticed an issue with descriptions coming in from my Jira not rendering properly in atom.

Some of the descriptions in our projects have multiple consecutive blank lines, this causes plugin to render them outside of the proper issue, destroying the structure.

This PR fixes it for me.

i.e.

```
// desc
//
// some words
// some more words
//
//
// test more words
```

such a description will be rendered properly.

Additionally, I've changed the linebreak in util to `'\n'` as this is the way the json returned by atlassian's API shows new lines for my Jira.

I assume it might be different `\r\n` (windows) for you ?

I haven't updated the `setDescription` and `addDescription` methods yet, wanted to get your opinion on the linebreak thing first.
